### PR TITLE
Vectorize voxel/sphere distance computation

### DIFF
--- a/scripts/step1_label_synthesis.py
+++ b/scripts/step1_label_synthesis.py
@@ -29,7 +29,7 @@ def calculate_distance(center_coords, grid_size=128):
     # Assign n_vox x n_spheres array:
     distances = np.zeros((grid_size**3, len(center_coords)))
 
-    # list of all voxel indices:
+    # array of all voxel indices:
     x = np.arange(grid_size)
     y = np.arange(grid_size)
     z = np.arange(grid_size)

--- a/scripts/step1_label_synthesis.py
+++ b/scripts/step1_label_synthesis.py
@@ -30,16 +30,17 @@ def calculate_distance(center_coords, grid_size=128):
     distances = np.zeros((grid_size**3, len(center_coords)))
 
     # list of all voxel indices:
-    vox_coord = list(
-        product(range(grid_size), range(grid_size), range(grid_size)),
-    )
+    x = np.arange(grid_size)
+    y = np.arange(grid_size)
+    z = np.arange(grid_size)
+    xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
+    vox_coord = np.stack([xx.ravel(), yy.ravel(), zz.ravel()], axis=1)
 
     # Calc. distance between each voxel and each sphere, loop through voxels:
-    # There should be a much faster way using vectorization.
-    for i in range(distances.shape[0]):
-        distances[i] = np.sqrt(
-            np.sum((np.array(vox_coord[i]) - center_coords)**2, axis=1)
-        )
+    # use broadcasting to speed things up
+    distances = np.sqrt(                                                  
+        np.sum((vox_coord[:, np.newaxis, :] - center_coords) ** 2, axis=2)
+    )                                                                     
     
     return distances
 


### PR DESCRIPTION
This PR vectorizes voxel-sphere distance computations. Earlier, the first step of label synthesis took a mean time of 7.7 seconds/label, which is now reduced to 2.38 seconds/label. I conducted these tests over synthesis of 20 labels, and have attached plots of each of these. Please let me know if this looks good to you, and is helpful!

Thank you,
Chaitanya

![vectorized](https://github.com/neel-dey/AnyStar/assets/49002516/10f22533-bc77-4085-b36c-85c54802f688)
![non-vectorized](https://github.com/neel-dey/AnyStar/assets/49002516/e89598cf-aaf5-431b-8ae4-6536f1b093ea)


